### PR TITLE
APPEX-126 Add methods to handle authentication, load, uninstall, and remove user callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,120 @@
 # Bigcommerce for Node.js
 
 A node module for authentication and communication with the BigCommerce API.
+
+## Installation (In Development)
+
+1. Clone this repository: `git clone git@github.com:bigcommerce/bigcommerce-api-node.git`
+2. Navigate into the cloned repository: `cd bigcommerce-api-node`
+3. Run [npm link](https://docs.npmjs.com/cli/v8/commands/npm-link): `npm link`
+
+Now, you can navigate into the directory of some other package (e.g., [sample-app-nodejs](https://github.com/bigcommerce/sample-app-nodejs)) and run `npm link bigcommerce-api-node` which will then allow you to use and test this package as if it was downloaded from NPM.
+
+## Usage
+
+First, import the package into your project:
+
+```js
+import BigCommerce from 'bigcommerce-api-node';
+```
+
+Then, create your BigCommerce object with configuration options relevant to your use case:
+
+```js
+const bigcommerce = new BigCommerce({
+  clientId: "YOUR_CLIENT_ID",
+  clientSecret: "YOUR_CLIENT_SECRET",
+  authCallback: "https://yourapplication.com/auth",
+  // ...etc.
+});
+```
+### Configuration Object
+
+These are the available properties that can be passed into the BigCommerce constructor when instantiating it:
+
+```js
+{
+  // Client ID (optional): Found in the BigCommerce DevTools dashboard when you create an app.
+  // Required to call the `authorize` method.
+  clientId: '123abc',
+
+  // Client Secret (optional): Found in the BigCommerce DevTools dashboard when you create an app.
+  // Required to call the `authorize` and `verifyJWT` methods.
+  clientSecret: '789xyz',
+
+  // Auth Callback (optional): URL used as the `redirect_uri` in the POST request to /oauth2/token.
+  // Required to call the `authorize` method.
+  authCallback: 'https://yourapplication.com/auth',
+
+  // API Host (optional): Defaults to 'api.bigcommerce.com'. You probably don't want to change this, 
+  // this option is here for internal BigCommerce employees mainly.
+  apiHost: 'api.bigcommerce.com',
+
+  // Login Host (optional): Defaults to 'login.bigcommerce.com'. You probably don't want to change this, 
+  // this option is here for internal BigCommerce employees mainly.
+  loginHost: 'login.bigcommerce.com',
+}
+```
+
+While all of the configuration properties above are labelled as 'optional', a subset of properties may be required depending on how you're using the BigCommerce client. For example, the section below on [Authentication](#authentication) requires that the BigCommerce configuration contains non-null values for `clientId`, `clientSecret`, and `authCallback`. 
+
+In the event that a method does not have values for required configuration properties, a `BigCommerceConfigurationError` will be thrown.
+
+## Authentication
+
+The `bigcommerce-api-node` package can be used to handle the OAuth flow that begins when a merchant clicks **Install** on a single-click app.
+
+First, create a BigCommerce object with `clientId`, `clientSecret`, and `authCallback` as configuration options:
+
+```js
+const bigcommerce = new BigCommerce({
+  clientId: "YOUR_CLIENT_ID",
+  clientSecret: "YOUR_CLIENT_SECRET",
+  authCallback: "https://yourapplication.com/auth",
+});
+```
+
+The `authorize` method takes one parameter — an object containing values for `code`, `scope`, and `context`, which are provided by the GET request to your store when a merchant installs your app.
+
+```js
+const session = await bigcommerce.authorize({code, scope, context});
+```
+
+The object stored in the `session` variable above will have the following shape:
+
+```js
+{
+  access_token: '123abc',
+  scope: 'store_v2_orders etc.',
+  user: {
+    id: 12345,
+    username: 'user.email@example.com',
+    email: 'user.email@example.com',
+  },
+  context: 'stores/{STORE_HASH}',
+  account_uuid: 'uuid-string'
+}
+```
+
+The `bigcommerce-api-node` package also ships with a `verifyJWT` method that can be used to verify and return the payload returned by the `load`, `uninstall`, and `remove User` callbacks. Each event triggers a GET request from BigCommerce to your app's callback endpoints containing a `signed_payload_jwt` as a query parameter. Once you parse the `signed_payload_jwt` from the request parameters, you can pass it to the `verifyJWT` method as follows:
+
+```js
+const session = bigcommerce.verifyJWT(signed_payload_jwt);
+```
+
+The object stored in the `session` variable above will have the following shape:
+
+```js
+{
+  aud: 'YOUR_CLIENT_ID',
+  iss: 'bc',
+  iat: 1646844813,
+  nbf: 1646844808,
+  exp: 1646931213,
+  jti: 'uuid-value',
+  sub: 'stores/{STORE_HASH}',
+  user: { id: 1470672, email: 'user.email@example.com' },
+  owner: { id: 1470672, email: 'owner.email@example.com' },
+  url: '/'
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,20 @@
 {
-  "name": "bigcommerce-api-node-reference",
+  "name": "bigcommerce-api-node",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "bigcommerce-api-node-reference",
+      "name": "bigcommerce-api-node",
       "version": "0.0.1",
+      "dependencies": {
+        "axios": "^0.26.1",
+        "jsonwebtoken": "^8.5.1",
+        "snake-case": "^3.0.4"
+      },
       "devDependencies": {
         "@bigcommerce/eslint-config": "^2.3.1",
+        "@types/jsonwebtoken": "^8.5.8",
         "@types/node": "^17.0.21",
         "eslint": "^8.10.0",
         "prettier": "^2.5.1",
@@ -204,6 +210,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "17.0.21",
@@ -571,6 +586,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -604,6 +627,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -773,6 +801,28 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dot-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -1479,6 +1529,25 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1987,6 +2056,35 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
@@ -1998,6 +2096,25 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -2041,6 +2158,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "node_modules/lodash.last": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
@@ -2052,6 +2199,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "node_modules/lodash.zipobject": {
       "version": "4.1.3",
@@ -2070,6 +2222,19 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lower-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2126,14 +2291,27 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/no-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -2580,7 +2758,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2660,6 +2837,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snake-case/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
@@ -3123,6 +3314,15 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/jsonwebtoken": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
@@ -3342,6 +3542,14 @@
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "dev": true
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -3372,6 +3580,11 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "call-bind": {
       "version": "1.0.2",
@@ -3495,6 +3708,30 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "emoji-regex": {
@@ -4039,6 +4276,11 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4400,6 +4642,30 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "jsx-ast-utils": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
@@ -4408,6 +4674,25 @@
       "requires": {
         "array-includes": "^3.1.3",
         "object.assign": "^4.1.2"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "language-subtag-registry": {
@@ -4445,6 +4730,36 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.last": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
@@ -4456,6 +4771,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.zipobject": {
       "version": "4.1.3",
@@ -4470,6 +4790,21 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "lru-cache": {
@@ -4515,14 +4850,29 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -4822,8 +5172,7 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4871,6 +5220,22 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "spdx-exceptions": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,14 @@
     "lint": "eslint --max-warnings 0 src/**/*.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "axios": "^0.26.1",
+    "jsonwebtoken": "^8.5.1",
+    "snake-case": "^3.0.4"
+  },
   "devDependencies": {
     "@bigcommerce/eslint-config": "^2.3.1",
+    "@types/jsonwebtoken": "^8.5.8",
     "@types/node": "^17.0.21",
     "eslint": "^8.10.0",
     "prettier": "^2.5.1",

--- a/src/BigCommerce.ts
+++ b/src/BigCommerce.ts
@@ -1,0 +1,114 @@
+import axios, { AxiosResponse } from 'axios';
+import { JwtPayload, verify } from 'jsonwebtoken';
+
+import { BigCommerceConfigurationError } from './errors/BigCommerceConfigurationError';
+import {
+  AuthCallbackQueryParams,
+  AuthResponsePayload,
+  BigCommerceConfig,
+  BigCommerceConfigProperties,
+} from './types';
+import { assertIsError } from './utils/assertIsError';
+import { keysToSnakeCase } from './utils/cases';
+
+class BigCommerce {
+  private config;
+
+  constructor(config: BigCommerceConfig) {
+    if (!Object.keys(config).length) {
+      throw new BigCommerceConfigurationError();
+    }
+
+    this.config = config;
+  }
+
+  /**
+   * Sends a POST request to the BigCommerce /oauth2/token endpoint
+   * to exchange the temporary access code provided by app installation
+   * for a permanent access_token that can be used to communicate with
+   * the BigCommerce API.
+   *
+   * @param {Object} query Required properties are code, scope, and context
+   * @param {string} query.code Temporary code to exchange for access_token
+   * @param {string} query.context Store hash, e.g., stores/{STORE_HASH}
+   * @param {string} query.scope List of scopes authorized by the user
+   * @returns {Promise<AuthResponsePayload>} Object containing access_token to use
+   *     for API requests
+   */
+  async authorize(query: AuthCallbackQueryParams): Promise<AuthResponsePayload> {
+    if (!Object.keys(query).length) {
+      throw new Error('Object must contain string values for code, context, and scope');
+    }
+
+    const { code, context, scope } = query;
+    const { clientId, clientSecret, authCallback } = this.config;
+    const loginHost = this.config.loginHost ?? 'login.bigcommerce.com';
+
+    if (!clientId) {
+      throw new BigCommerceConfigurationError(BigCommerceConfigProperties.ClientId);
+    }
+
+    if (!clientSecret) {
+      throw new BigCommerceConfigurationError(BigCommerceConfigProperties.ClientSecret);
+    }
+
+    if (!authCallback) {
+      throw new BigCommerceConfigurationError(BigCommerceConfigProperties.AuthCallback);
+    }
+
+    const payload = keysToSnakeCase({
+      clientId,
+      clientSecret,
+      redirectUri: authCallback,
+      grantType: 'authorization_code',
+      code,
+      scope,
+      context,
+    });
+
+    try {
+      const { data } = await axios.post<AuthResponsePayload, AxiosResponse<AuthResponsePayload>>(
+        `https://${loginHost}/oauth2/token`,
+        payload,
+      );
+
+      return data;
+    } catch (error) {
+      assertIsError(error);
+
+      throw new Error('Authorize request returned an error', { cause: error });
+    }
+  }
+
+  /**
+   * Verify signed_payload_jwt from load/uninstall/remove user callbacks
+   *
+   * @param {string} signedPayloadJWT JWT provided in callback query params
+   * @returns {JwtPayload} Decoded JWT containing store hash, user,
+   *     and owner information
+   */
+  verifyJWT(signedPayloadJWT: string): JwtPayload {
+    const { clientSecret, clientId } = this.config;
+
+    if (!clientId) {
+      throw new BigCommerceConfigurationError(BigCommerceConfigProperties.ClientId);
+    }
+
+    if (!clientSecret) {
+      throw new BigCommerceConfigurationError(BigCommerceConfigProperties.ClientSecret);
+    }
+
+    const decoded = verify(signedPayloadJWT, clientSecret, {
+      algorithms: ['HS256'],
+      audience: clientId,
+    });
+
+    if (typeof decoded === 'string') {
+      throw new Error('Signed payload must be of an object type');
+    }
+
+    return decoded;
+  }
+}
+
+export default BigCommerce;

--- a/src/errors/BigCommerceConfigurationError.ts
+++ b/src/errors/BigCommerceConfigurationError.ts
@@ -1,0 +1,16 @@
+import { BigCommerceConfigProperties } from '../types';
+
+export class BigCommerceConfigurationError extends Error {
+  missing: string | undefined;
+
+  constructor(missing?: BigCommerceConfigProperties) {
+    if (!missing) {
+      super('Required configuration object is missing');
+    } else {
+      super(`Missing required configuration property: ${missing}`);
+      this.missing = missing;
+    }
+
+    this.name = 'BigCommerceConfigurationError';
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+import BigCommerce from './BigCommerce';
+
+export default BigCommerce;
+export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,55 @@
+export interface BigCommerceConfig {
+  clientId?: string;
+  clientSecret?: string;
+  authCallback?: string;
+  loginHost?: string;
+}
+
+export enum BigCommerceConfigProperties {
+  ClientId = 'clientId',
+  ClientSecret = 'clientSecret',
+  AuthCallback = 'authCallback',
+  ApiHost = 'apiHost',
+  LoginHost = 'loginHost',
+}
+
+export interface AuthCallbackQueryParams {
+  code: string;
+  scope: string;
+  context: string;
+}
+
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface AuthResponsePayload {
+  access_token: string;
+  scope: string;
+  user: User;
+  context: string;
+  account_uuid: string;
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+}
+
+export interface VerifiedJwt {
+  aud: string;
+  iss: string;
+  iat: number;
+  nbf: number;
+  exp: number;
+  jti: string;
+  sub: string;
+  user: {
+    id: number;
+    email: string;
+  };
+  owner: {
+    id: number;
+    email: string;
+  };
+  url: string;
+}

--- a/src/utils/assertIsError.ts
+++ b/src/utils/assertIsError.ts
@@ -1,0 +1,10 @@
+/**
+ * This function asserts that an unknown type (typically an error in a
+ * catch block) is of type Error, which means for the rest of the scope,
+ * the unknown type can safely be treated as a type of Error.
+ */
+export function assertIsError(error: unknown): asserts error is Error {
+  if (!(error instanceof Error)) {
+    throw error;
+  }
+}

--- a/src/utils/cases.ts
+++ b/src/utils/cases.ts
@@ -1,0 +1,11 @@
+import { snakeCase } from 'snake-case';
+
+/**
+ * Transforms an object's keys to snake_case
+ *
+ * @param {Object} object An object whose keys you want to transform to snake_case
+ * @returns {Object} An object with keys transformed to snake_case
+ */
+export function keysToSnakeCase(object: { [k: string]: string }) {
+  return Object.fromEntries(Object.entries(object).map(([k, v]) => [snakeCase(k), v]));
+}


### PR DESCRIPTION
#### What?

This pull request adds a `BigCommerce` class along with two public methods:
- `authorize`: Provided with `code`, `scope`, and `context` parameters, this method will construct and send a POST request to the /oauth2/token endpoint to exchange the temporary `code` for a permanent `access_token`. 
- `verifyJWT`: Provided with a `signed_payload_jwt`, this method will verify and return the decoded JWT containing information about the Control Panel user that triggered the callback.

#### Tickets / Documentation

-   [APPEX-126](https://jira.bigcommerce.com/browse/APPEX-126)

#### Testing

1. Clone this repository/branch
2. While in the working directory of this branch on your local machine, run `npm link` (more info: https://docs.npmjs.com/cli/v8/commands/npm-link)
3. You can now run `npm link bigcommerce-api-node` in another project to import the `bigcommerce-api-node` package into that project
4. Clone [sample-app-nodejs](https://github.com/bigcommerce/sample-app-nodejs) and navigate into its directory on your local machine
5. run `npm link bigcommerce-api-node`
6. Import the `BigCommerce` object as described in the README
7. Replace the existing `authorize` and `verifyJWT` methods in the sample-app with the methods from this package
8. Install the sample-app as a Draft App in a BigCommerce store and confirm the app installs and loads properly. 

cc @bigcommerce/gta-dt
