### PR TITLE
APPEX-266 adds tests for v2 orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Then, create a BigCommerce object with configuration options relevant to your us
 
 The main `BigCommerce` import is an object that contains properties for different use cases of the BigCommerce Node Client. The properties available are described below:
 
-* `Auth`: This class can be instantiated and used to handle the OAuth flow that begins when a merchant clicks **Install** on a single-click app. 
+* `Auth`: This class can be instantiated and used to handle the OAuth flow that begins when a merchant clicks **Install** on a single-click app.
+* `Rest`: This class can be instantiated and used to make API requests to the BigCommerce Public REST API.
 
 ## OAuth
 
@@ -86,7 +87,7 @@ The object stored in the `payload` variable above will contain the following key
 }
 ```
 
-## REST API Resources
+## REST
 
 The `bigcommerce-api-node` package can be used to communicate with the BigCommerce Public REST API.
 

--- a/src/RestClient/RestClient.spec.ts
+++ b/src/RestClient/RestClient.spec.ts
@@ -1,0 +1,39 @@
+import mockAxios from 'jest-mock-axios';
+
+import RestClient from './index';
+
+describe('RestClient', () => {
+  describe('constructor', () => {
+    it('should throw error for missing storeHash', () => {
+      const bigcommerceRest = () =>
+        // @ts-expect-error testing missing storeHash param
+        new RestClient({ accessToken: '987654321' });
+      expect(bigcommerceRest).toThrow('storeHash');
+    });
+
+    it('should throw error for missing accessToken', () => {
+      const bigcommerceRest = () =>
+        // @ts-expect-error testing missing accessToken param
+        new RestClient({ storeHash: 'abcdefgh1i' });
+      expect(bigcommerceRest).toThrow('accessToken');
+    });
+
+    it('should allow apiHost to be overridden', () => {
+      const config = {
+        storeHash: 'abcdefgh1i',
+        accessToken: '987654321',
+        apiHost: 'api.custom.com',
+      };
+
+      new RestClient(config);
+
+      expect(mockAxios.create).toHaveBeenCalledWith({
+        baseURL: `https://${config.apiHost}/stores/${config.storeHash}`,
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'X-Auth-Token': config.accessToken,
+        },
+      });
+    });
+  });
+});

--- a/src/RestClient/endpoints/Orders/v2/OrderCoupons.spec.ts
+++ b/src/RestClient/endpoints/Orders/v2/OrderCoupons.spec.ts
@@ -1,0 +1,71 @@
+import mockAxios from 'jest-mock-axios';
+
+import { paginateById } from '../../../../utils/paginate';
+
+import OrderCoupons from './OrderCoupons';
+
+jest.mock('../../../../utils/paginate');
+
+const mockClient = mockAxios.create();
+
+describe('OrderCoupons', () => {
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  describe('OrderCoupons REST Methods', () => {
+    // @ts-expect-error testing ordersV2 constructor
+    const orderCoupons = new OrderCoupons(mockClient);
+    const thenFn = jest.fn();
+    const catchFn = jest.fn();
+
+    describe('list', () => {
+      it('should perform a get request to the order coupons endpoint without parameters', () => {
+        const orderId = 100;
+
+        void orderCoupons.list(orderId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/coupons`, { params: undefined });
+      });
+
+      it('should perform a get request to the order coupons endpoint with parameters', () => {
+        const orderId = 100;
+        const filters = { limit: 5 };
+
+        void orderCoupons.list(orderId, filters);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/coupons`, { params: filters });
+      });
+
+      it('should return a promise that resolves to the response data for order coupons', () => {
+        const orderId = 100;
+
+        orderCoupons.list(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: [{ id: 150, type: 0 }],
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('listAll', () => {
+      it('should call paginateById with the provided order id', () => {
+        const orderId = 100;
+
+        orderCoupons.listAll(orderId);
+
+        expect(paginateById).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/RestClient/endpoints/Orders/v2/OrderMessages.spec.ts
+++ b/src/RestClient/endpoints/Orders/v2/OrderMessages.spec.ts
@@ -1,0 +1,72 @@
+import mockAxios from 'jest-mock-axios';
+
+import { paginateById } from '../../../../utils/paginate';
+
+import OrderMessages from './OrderMessages';
+
+jest.mock('../../../../utils/paginate');
+
+const mockClient = mockAxios.create();
+
+describe('OrderMessages', () => {
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  describe('OrderMessages REST Methods', () => {
+    // @ts-expect-error testing ordersV2 constructor
+    const orderMessages = new OrderMessages(mockClient);
+    const thenFn = jest.fn();
+    const catchFn = jest.fn();
+
+    describe('list', () => {
+      it('should perform a get request to the order messages endpoint without parameters', () => {
+        const orderId = 100;
+
+        void orderMessages.list(orderId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/messages`, { params: undefined });
+      });
+
+      it('should perform a get request to the order messages endpoint without parameters', () => {
+        const orderId = 100;
+        const filters = { limit: 5 };
+
+        void orderMessages.list(orderId, filters);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/messages`, { params: filters });
+      });
+
+      it('should return a promise that resolves to the response data for order messages', () => {
+        const orderId = 100;
+        const messageId = 150;
+
+        orderMessages.list(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: [{ id: messageId }],
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('listAll', () => {
+      it('should call paginateById with the provided order id', () => {
+        const orderId = 100;
+
+        orderMessages.listAll(orderId);
+
+        expect(paginateById).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/RestClient/endpoints/Orders/v2/OrderProducts.spec.ts
+++ b/src/RestClient/endpoints/Orders/v2/OrderProducts.spec.ts
@@ -1,0 +1,104 @@
+import mockAxios from 'jest-mock-axios';
+
+import { paginateById } from '../../../../utils/paginate';
+
+import OrderProducts from './OrderProducts';
+
+jest.mock('../../../../utils/paginate');
+
+const mockClient = mockAxios.create();
+
+describe('OrderProducts', () => {
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  describe('OrderProducts REST Methods', () => {
+    // @ts-expect-error testing ordersV2 constructor
+    const orderProducts = new OrderProducts(mockClient);
+    const thenFn = jest.fn();
+    const catchFn = jest.fn();
+
+    describe('list', () => {
+      it('should perform a get request to the order products endpoint without parameters', () => {
+        const orderId = 100;
+
+        void orderProducts.list(orderId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/products`, { params: undefined });
+      });
+
+      it('should perform a get request to the order products endpoint with parameters', () => {
+        const orderId = 100;
+        const filters = { limit: 5 };
+
+        void orderProducts.list(orderId, filters);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/products`, { params: filters });
+      });
+
+      it('should return a promise that resolves to the response data for order products', () => {
+        const orderId = 100;
+        const productId = 150;
+
+        orderProducts.list(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: [{ id: productId }],
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('listAll', () => {
+      it('should call paginateById with the provided order id', () => {
+        const orderId = 100;
+
+        orderProducts.listAll(orderId);
+
+        expect(paginateById).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('get', () => {
+      it('should perform a get request to the order products endpoint', () => {
+        const orderId = 100;
+        const productId = 150;
+
+        void orderProducts.get(orderId, productId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/products/${productId}`);
+      });
+
+      it('should return a promise that resolves to the response data for an order product', () => {
+        const orderId = 100;
+        const productId = 150;
+
+        orderProducts.get(orderId, productId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: { id: productId },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/RestClient/endpoints/Orders/v2/OrderShipments.spec.ts
+++ b/src/RestClient/endpoints/Orders/v2/OrderShipments.spec.ts
@@ -1,0 +1,280 @@
+import mockAxios from 'jest-mock-axios';
+
+import { paginateById } from '../../../../utils/paginate';
+
+import OrderShipments from './OrderShipments';
+
+jest.mock('../../../../utils/paginate');
+
+const mockClient = mockAxios.create();
+
+describe('OrderShipments', () => {
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  describe('OrderShipments REST Methods', () => {
+    // @ts-expect-error testing ordersV2 constructor
+    const orderShipments = new OrderShipments(mockClient);
+    const thenFn = jest.fn();
+    const catchFn = jest.fn();
+
+    describe('list', () => {
+      it('should perform a get request to the order shipments endpoint without parameters', () => {
+        const orderId = 100;
+
+        void orderShipments.list(orderId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipments`, { params: undefined });
+      });
+
+      it('should perform a get request to the order shipments endpoint with parameters', () => {
+        const orderId = 100;
+        const filters = { limit: 5 };
+
+        void orderShipments.list(orderId, filters);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipments`, { params: filters });
+      });
+
+      it('should return a promise that resolves to the response data for order shipments', () => {
+        const orderId = 100;
+        const shipmentId = 150;
+
+        orderShipments.list(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: [{ id: shipmentId }],
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('listAll', () => {
+      it('should call paginateById with the provided order id', () => {
+        const orderId = 100;
+
+        orderShipments.listAll(orderId);
+
+        expect(paginateById).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('create', () => {
+      it('should perform a post request to the order shipments endpoint with user supplied data', () => {
+        const orderId = 100;
+        const data = {
+          order_address_id: 1,
+          items: [
+            {
+              order_product_id: 1,
+              quantity: 1,
+            },
+          ],
+        };
+
+        void orderShipments.create(orderId, data);
+
+        expect(mockClient.post).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipments`, data);
+      });
+
+      it('should return a promise that resolves to the response data for a new shipment', () => {
+        const orderId = 100;
+        const shipmentId = 150;
+        const data = {
+          order_address_id: 1,
+          items: [
+            {
+              order_product_id: 1,
+              quantity: 1,
+            },
+          ],
+        };
+
+        orderShipments.create(orderId, data).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: { id: shipmentId },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('deleteAll', () => {
+      it('should perform a delete request to the order shipments endpoint', () => {
+        const orderId = 100;
+
+        void orderShipments.deleteAll(orderId);
+
+        expect(mockClient.delete).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipments`);
+      });
+
+      it('should return a promise that resolves to a 204 No Content response', () => {
+        const orderId = 100;
+
+        orderShipments.deleteAll(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 204,
+          statusText: 'No Content',
+          data: '',
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('count', () => {
+      it('should perform a get request to the order shipments count endpoint', () => {
+        const orderId = 100;
+
+        void orderShipments.count(orderId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipments/count`);
+      });
+
+      it('should return a promise that resolves to the response data for a shipment count', () => {
+        const orderId = 100;
+        const numOrders = 150;
+
+        orderShipments.count(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: { count: numOrders },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('get', () => {
+      it('should perform a get request to the order shipment endpoint', () => {
+        const orderId = 100;
+        const shipmentId = 150;
+
+        void orderShipments.get(orderId, shipmentId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipments/${shipmentId}`);
+      });
+
+      it('should return a promise that resolves to the response data for a shipment', () => {
+        const orderId = 100;
+        const shipmentId = 150;
+
+        orderShipments.get(orderId, shipmentId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: { id: shipmentId },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('update', () => {
+      it('should perform a put request to the order shipment endpoint with user supplied data', () => {
+        const orderId = 100;
+        const shipmentId = 150;
+        const data = { tracking_number: '12345' };
+
+        void orderShipments.update(orderId, shipmentId, data);
+
+        expect(mockClient.put).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipments/${shipmentId}`, data);
+      });
+
+      it('should return a promise that resolves to the response data for an updated shipment', () => {
+        const orderId = 100;
+        const shipmentId = 150;
+        const data = { tracking_number: '12345' };
+
+        orderShipments.update(orderId, shipmentId, data).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: { id: shipmentId },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('delete', () => {
+      it('should perform a delete request to the order shipment endpoint', () => {
+        const orderId = 100;
+        const shipmentId = 150;
+
+        void orderShipments.delete(orderId, shipmentId);
+
+        expect(mockClient.delete).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipments/${shipmentId}`);
+      });
+
+      it('should return a promise that resolves to a 204 No Content response', () => {
+        const orderId = 100;
+        const shipmentId = 150;
+
+        orderShipments.delete(orderId, shipmentId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 204,
+          statusText: 'No Content',
+          data: '',
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/RestClient/endpoints/Orders/v2/OrderShippingAddresses.spec.ts
+++ b/src/RestClient/endpoints/Orders/v2/OrderShippingAddresses.spec.ts
@@ -1,0 +1,145 @@
+import mockAxios from 'jest-mock-axios';
+
+import { paginateById } from '../../../../utils/paginate';
+
+import OrderShippingAddresses from './OrderShippingAddresses';
+
+jest.mock('../../../../utils/paginate');
+
+const mockClient = mockAxios.create();
+
+describe('OrderShippingAddresses', () => {
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  describe('OrderShippingAddresses REST Methods', () => {
+    // @ts-expect-error testing ordersV2 constructor
+    const orderShippingAddresses = new OrderShippingAddresses(mockClient);
+    const thenFn = jest.fn();
+    const catchFn = jest.fn();
+
+    describe('list', () => {
+      it('should perform a get request to the order shipping addresses endpoint without parameters', () => {
+        const orderId = 100;
+
+        void orderShippingAddresses.list(orderId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipping_addresses`, { params: undefined });
+      });
+
+      it('should perform a get request to the order shipping addresses endpoint with parameters', () => {
+        const orderId = 100;
+        const filters = { limit: 5 };
+
+        void orderShippingAddresses.list(orderId, filters);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipping_addresses`, { params: filters });
+      });
+
+      it('should return a promise that resolves to the response data for order shipping addresses', () => {
+        const orderId = 100;
+        const shippingAddressId = 150;
+
+        orderShippingAddresses.list(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: [{ id: shippingAddressId }],
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('listAll', () => {
+      it('should call paginateById with the provided order id', () => {
+        const orderId = 100;
+
+        orderShippingAddresses.listAll(orderId);
+
+        expect(paginateById).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('get', () => {
+      it('should perform a get request to the order shipping address endpoint', () => {
+        const orderId = 100;
+        const shippingAddressId = 150;
+
+        void orderShippingAddresses.get(orderId, shippingAddressId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/shipping_addresses/${shippingAddressId}`);
+      });
+
+      it('should return a promise that resolves to the response data for an order shipping address', () => {
+        const orderId = 100;
+        const shippingAddressId = 150;
+
+        orderShippingAddresses.get(orderId, shippingAddressId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: { id: shippingAddressId },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('update', () => {
+      it('should perform a put request to the order shipping address endpoint with user supplied data', () => {
+        const orderId = 100;
+        const shippingAddressId = 150;
+        const data = {
+          first_name: 'John Doe',
+        };
+
+        void orderShippingAddresses.update(orderId, shippingAddressId, data);
+
+        expect(mockClient.put).toHaveBeenCalledWith(
+          `/v2/orders/${orderId}/shipping_addresses/${shippingAddressId}`,
+          data,
+        );
+      });
+
+      it('should return a promise that resolves to the response data for an updated shipping address', () => {
+        const orderId = 100;
+        const shippingAddressId = 150;
+        const data = {
+          first_name: 'John Doe',
+        };
+
+        orderShippingAddresses.update(orderId, shippingAddressId, data).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: { id: shippingAddressId },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/RestClient/endpoints/Orders/v2/OrderShippingQuotes.spec.ts
+++ b/src/RestClient/endpoints/Orders/v2/OrderShippingQuotes.spec.ts
@@ -1,0 +1,53 @@
+import mockAxios from 'jest-mock-axios';
+
+import OrderShippingQuotes from './OrderShippingQuotes';
+
+const mockClient = mockAxios.create();
+
+describe('OrderShippingQuotes', () => {
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  describe('OrderShippingQuotes REST Methods', () => {
+    // @ts-expect-error testing ordersV2 constructor
+    const orderShippingQuotes = new OrderShippingQuotes(mockClient);
+    const thenFn = jest.fn();
+    const catchFn = jest.fn();
+
+    describe('list', () => {
+      it('should perform a get request to the order shipping quotes endpoint', () => {
+        const orderId = 100;
+        const shippingAddressId = 150;
+
+        void orderShippingQuotes.list(orderId, shippingAddressId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(
+          `/v2/orders/${orderId}/shipping_addresses/${shippingAddressId}/shipping_quotes`,
+        );
+      });
+
+      it('should return a promise that resolves to the response data for order shipping quotes', () => {
+        const orderId = 100;
+        const shippingAddressId = 150;
+        const shippingQuoteId = 200;
+
+        orderShippingQuotes.list(orderId, shippingAddressId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: { id: shippingQuoteId },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/RestClient/endpoints/Orders/v2/OrderStatus.spec.ts
+++ b/src/RestClient/endpoints/Orders/v2/OrderStatus.spec.ts
@@ -1,0 +1,76 @@
+import mockAxios from '../../../../__mocks__/axios';
+
+import OrderStatus from './OrderStatus';
+
+const mockClient = mockAxios.create();
+
+describe('OrderStatus', () => {
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  describe('OrderStatus REST Methods', () => {
+    // @ts-expect-error testing ordersV2 constructor
+    const orderStatus = new OrderStatus(mockClient);
+    const thenFn = jest.fn();
+    const catchFn = jest.fn();
+
+    describe('list', () => {
+      it('should perform a get request to the order status endpoint', () => {
+        void orderStatus.list();
+
+        expect(mockClient.get).toHaveBeenCalledWith('/v2/order_statuses/');
+      });
+
+      it('should return a promise that resolves to the response data for store order statuses', () => {
+        const orderStatusId = 0;
+
+        orderStatus.list().then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: [{ id: orderStatusId }],
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('get', () => {
+      it('should perform a get request to the order statuses endpoint', () => {
+        const orderStatusId = 0;
+
+        void orderStatus.get(orderStatusId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/order_statuses/${orderStatusId}`);
+      });
+
+      it('should return a promise that resolves to the response data for a single order status in a store', () => {
+        const orderStatusId = 0;
+
+        orderStatus.get(orderStatusId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: { id: orderStatusId },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/RestClient/endpoints/Orders/v2/OrderStatus.ts
+++ b/src/RestClient/endpoints/Orders/v2/OrderStatus.ts
@@ -10,7 +10,7 @@ const basePath = '/v2/order_statuses';
  * @param id Optional Order Status ID
  * @returns Either '/v2/order_statuses/:orderStatusId' or '/v2/order_statuses'
  */
-const getBasePath = (id?: number): string => `${basePath}${id ? `/${id}` : ''}`;
+const getBasePath = (id?: number): string => `${basePath}/${id ?? ''}`;
 
 class OrderStatus {
   private client: AxiosInstance;

--- a/src/RestClient/endpoints/Orders/v2/OrderTaxes.spec.ts
+++ b/src/RestClient/endpoints/Orders/v2/OrderTaxes.spec.ts
@@ -1,0 +1,73 @@
+import mockAxios from 'jest-mock-axios';
+
+import { paginateById } from '../../../../utils/paginate';
+
+import OrderTaxes from './OrderTaxes';
+
+jest.mock('../../../../utils/paginate');
+
+const mockClient = mockAxios.create();
+
+describe('OrderTaxes', () => {
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  describe('OrderTaxes REST Methods', () => {
+    // @ts-expect-error testing ordersV2 constructor
+    const orderTaxes = new OrderTaxes(mockClient);
+    const thenFn = jest.fn();
+    const catchFn = jest.fn();
+
+    describe('list', () => {
+      it('should perform a get request to the order taxes endpoint without parameters', () => {
+        const orderId = 100;
+
+        void orderTaxes.list(orderId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/taxes`, { params: undefined });
+      });
+
+      it('should perform a get request to the order taxes endpoint with parameters', () => {
+        const orderId = 100;
+        const filters = { limit: 5 };
+
+        void orderTaxes.list(orderId, filters);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}/taxes`, { params: filters });
+      });
+
+      it('should return a promise that resolves to the response data for order taxes', () => {
+        const orderId = 100;
+        const taxObjectId = 150;
+        const taxClassId = 1;
+
+        orderTaxes.list(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: [{ id: taxObjectId, tax_class_id: taxClassId }],
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('listAll', () => {
+      it('should call paginateById with the provided order id', () => {
+        const orderId = 100;
+
+        orderTaxes.listAll(orderId);
+
+        expect(paginateById).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/RestClient/endpoints/Orders/v2/index.spec.ts
+++ b/src/RestClient/endpoints/Orders/v2/index.spec.ts
@@ -1,0 +1,287 @@
+import mockAxios from 'jest-mock-axios';
+
+import { paginate } from '../../../../utils/paginate';
+
+import OrderCoupons from './OrderCoupons';
+import OrderMessages from './OrderMessages';
+import OrderProducts from './OrderProducts';
+import OrderShipments from './OrderShipments';
+import OrderShippingAddresses from './OrderShippingAddresses';
+import OrderShippingQuotes from './OrderShippingQuotes';
+import OrderStatus from './OrderStatus';
+import OrderTaxes from './OrderTaxes';
+
+import OrdersV2 from './index';
+
+jest.mock('../../../../utils/paginate');
+
+const mockClient = mockAxios.create();
+
+describe('OrdersV2', () => {
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  // @ts-expect-error testing OrdersV2 constructor
+  const ordersV2 = new OrdersV2(mockClient);
+
+  it('should instantiate and expose V2 order properties', () => {
+    expect(ordersV2.orderCoupons).toBeInstanceOf(OrderCoupons);
+    expect(ordersV2.orderProducts).toBeInstanceOf(OrderProducts);
+    expect(ordersV2.orderTaxes).toBeInstanceOf(OrderTaxes);
+    expect(ordersV2.orderStatus).toBeInstanceOf(OrderStatus);
+    expect(ordersV2.orderShipments).toBeInstanceOf(OrderShipments);
+    expect(ordersV2.orderShippingAddresses).toBeInstanceOf(OrderShippingAddresses);
+    expect(ordersV2.orderMessages).toBeInstanceOf(OrderMessages);
+    expect(ordersV2.orderShippingQuotes).toBeInstanceOf(OrderShippingQuotes);
+  });
+
+  describe('OrdersV2 REST Methods', () => {
+    const thenFn = jest.fn();
+    const catchFn = jest.fn();
+
+    describe('get', () => {
+      it('should perform a get request to the orders endpoint', () => {
+        const orderId = 100;
+
+        void ordersV2.get(orderId);
+
+        expect(mockClient.get).toHaveBeenCalledWith(`/v2/orders/${orderId}`);
+      });
+
+      it('should return a promise that resolves to the response data for a single order', () => {
+        const orderId = 100;
+
+        ordersV2.get(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: {
+            id: orderId,
+          },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('update', () => {
+      it('should perform a put request to the orders update endpoint', () => {
+        const orderId = 100;
+        const customerId = 200;
+
+        void ordersV2.update(orderId, { customer_id: customerId });
+
+        expect(mockClient.put).toHaveBeenCalledWith(`/v2/orders/${orderId}`, { customer_id: customerId });
+      });
+
+      it('should return a promise that resolves to the response data for a single order update', () => {
+        const orderId = 100;
+        const customerId = 200;
+
+        ordersV2.update(orderId, { customer_id: customerId }).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: {
+            id: orderId,
+            customer_id: customerId,
+          },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('archive', () => {
+      it('should perform a delete request to the orders delete endpoint', () => {
+        const orderId = 100;
+
+        void ordersV2.archive(orderId);
+
+        expect(mockClient.delete).toHaveBeenCalledWith(`/v2/orders/${orderId}`);
+      });
+
+      it('should return a promise that resolves to a 204 No Content response', () => {
+        const orderId = 100;
+
+        ordersV2.archive(orderId).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 204,
+          statusText: 'No Content',
+          data: '',
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('count', () => {
+      it('should perform a get request to the orders count endpoint', () => {
+        void ordersV2.count();
+
+        expect(mockClient.get).toHaveBeenCalledWith('/v2/orders/count');
+      });
+
+      it('should return a promise that resolves to the response data for a order count', () => {
+        ordersV2.count().then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: {
+            statuses: [
+              {
+                id: 0,
+                name: 'Incomplete',
+                system_label: 'Incomplete',
+                custom_label: 'Incomplete',
+                system_description:
+                  'An incomplete order happens when a shopper reached the payment page, but did not complete the transaction.',
+                count: 18,
+                sort_order: 0,
+              },
+            ],
+            count: 150,
+          },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('list', () => {
+      it('should perform a get request to the orders endpoint without parameters', () => {
+        void ordersV2.list();
+
+        expect(mockClient.get).toHaveBeenCalledWith('/v2/orders', { params: undefined });
+      });
+
+      it('should perform a get request to the orders endpoint with filter parameters', () => {
+        const filters = { limit: 5 };
+
+        void ordersV2.list(filters);
+
+        expect(mockClient.get).toHaveBeenCalledWith('/v2/orders', { params: filters });
+      });
+
+      it('should return a promise that resolves to the response data for all orders', () => {
+        ordersV2.list().then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: [{ id: 100 }, { id: 101 }],
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('listAll', () => {
+      it('should call paginate', () => {
+        ordersV2.listAll();
+
+        expect(paginate).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('create', () => {
+      it('should perform a post request to the orders create endpoint with user supplied data', () => {
+        const data = {
+          billing_address: { zip: '12345' },
+          products: [{ name: 'test', price_ex_tax: 10, price_inc_tax: 10, quantity: 1 }],
+        };
+
+        void ordersV2.create(data);
+
+        expect(mockClient.post).toHaveBeenCalledWith('/v2/orders', data);
+      });
+
+      it('should return a promise that resolves to the response data for a single created order', () => {
+        const data = {
+          billing_address: { zip: '12345' },
+          products: [{ name: 'test', price_ex_tax: 10, price_inc_tax: 10, quantity: 1 }],
+        };
+
+        ordersV2.create(data).then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 200,
+          statusText: 'OK',
+          data: {
+            id: 100,
+            billing_address: { zip: '12345' },
+          },
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('archiveAll', () => {
+      it('should perform a delete request to the orders delete endpoint', () => {
+        void ordersV2.archiveAll();
+
+        expect(mockClient.delete).toHaveBeenCalledWith('/v2/orders');
+      });
+
+      it('should return a promise that resolves to a 204 No Content response', () => {
+        ordersV2.archiveAll().then(thenFn).catch(catchFn);
+
+        const response = {
+          config: {},
+          headers: {},
+          status: 204,
+          statusText: 'No Content',
+          data: '',
+        };
+
+        mockClient.mockResponse(response);
+
+        expect(thenFn).toHaveBeenCalledWith(response);
+
+        expect(catchFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,6 @@
 import OAuth from './OAuth';
+import RestClient from './RestClient';
+import OrdersV2 from './RestClient/endpoints/Orders/v2';
 
 import BigCommerce from './index';
 
@@ -13,5 +15,20 @@ describe('BigCommerce API Client', () => {
     it('should be a class', () => {
       expect(auth).toBeInstanceOf(OAuth);
     });
+  });
+});
+
+describe('BigCommerce REST', () => {
+  const rest = new BigCommerce.Rest({
+    storeHash: 'abcdefgh1i',
+    accessToken: '987654321',
+  });
+
+  it('should be a class', () => {
+    expect(rest).toBeInstanceOf(RestClient);
+  });
+
+  it('should instantiate and expose a ordersV2 property', () => {
+    expect(rest.ordersV2).toBeInstanceOf(OrdersV2);
   });
 });

--- a/src/utils/paginate.spec.ts
+++ b/src/utils/paginate.spec.ts
@@ -1,0 +1,102 @@
+import { paginate, paginateById } from './paginate';
+
+const mockList = jest.fn();
+
+beforeEach(() => {
+  mockList.mockReturnValueOnce(
+    new Promise((resolve) =>
+      resolve({
+        data: [{ id: 1 }, { id: 2 }],
+      }),
+    ),
+  );
+
+  mockList.mockReturnValueOnce(
+    new Promise((resolve) =>
+      resolve({
+        data: [{ id: 3 }, { id: 4 }],
+      }),
+    ),
+  );
+
+  mockList.mockReturnValueOnce(
+    new Promise((resolve) =>
+      resolve({
+        data: [],
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  mockList.mockClear();
+});
+
+describe('paginate', () => {
+  it('should be a function', () => {
+    expect(paginate).toBeInstanceOf(Function);
+  });
+
+  it('should call listFn, returning one item from the result of listFn at a time', async () => {
+    // @ts-expect-error testing paginate generator
+    const generator = paginate(mockList);
+
+    expect(await generator.next()).toEqual({ done: false, value: { id: 1 } });
+    expect(await generator.next()).toEqual({ done: false, value: { id: 2 } });
+
+    expect(mockList).toHaveBeenCalledWith({ page: 1 });
+
+    expect(await generator.next()).toEqual({ done: false, value: { id: 3 } });
+    expect(await generator.next()).toEqual({ done: false, value: { id: 4 } });
+
+    expect(mockList).toHaveBeenCalledWith({ page: 2 });
+
+    expect(await generator.next()).toEqual({ done: true });
+  });
+
+  it('should allow the starting page to be overridden if provided as a parameter', async () => {
+    const generator = paginate(mockList, { page: 2 });
+
+    expect(await generator.next()).toEqual({ done: false, value: { id: 1 } });
+
+    expect(mockList).toHaveBeenCalledWith({ page: 2 });
+  });
+});
+
+describe('paginateById', () => {
+  it('should be a function', () => {
+    expect(paginateById).toBeInstanceOf(Function);
+  });
+
+  it('should call listFn with the provided id', async () => {
+    // @ts-expect-error testing paginateById order id parameter
+    const generator = paginateById(mockList, 100);
+    await generator.next();
+
+    expect(mockList).toHaveBeenCalledWith(100, { page: 1 });
+  });
+
+  it('should allow the starting page to be overridden if provided as a parameter', async () => {
+    const generator = paginateById(mockList, 100, { page: 2 });
+    await generator.next();
+
+    expect(mockList).toHaveBeenCalledWith(100, { page: 2 });
+  });
+
+  it('should call listFn with an id, returning one item from the result of listFn at a time', async () => {
+    // @ts-expect-error testing paginate generator
+    const generator = paginateById(mockList, 100);
+
+    expect(await generator.next()).toEqual({ done: false, value: { id: 1 } });
+    expect(await generator.next()).toEqual({ done: false, value: { id: 2 } });
+
+    expect(mockList).toHaveBeenCalledWith(100, { page: 1 });
+
+    expect(await generator.next()).toEqual({ done: false, value: { id: 3 } });
+    expect(await generator.next()).toEqual({ done: false, value: { id: 4 } });
+
+    expect(mockList).toHaveBeenCalledWith(100, { page: 2 });
+
+    expect(await generator.next()).toEqual({ done: true });
+  });
+});

--- a/src/utils/required.spec.ts
+++ b/src/utils/required.spec.ts
@@ -1,0 +1,7 @@
+import { required } from './required';
+
+describe('required', () => {
+  it('should always throw an error with a string describing what parameter is missing', () => {
+    expect(() => required('parameterName')).toThrowError('Missing required parameter: parameterName');
+  });
+});

--- a/src/utils/required.ts
+++ b/src/utils/required.ts
@@ -1,0 +1,14 @@
+/**
+ * Function that throws an error if a parameter is not provided.
+ *
+ * @example
+ * function foo(bar: string = required('bar')) {
+ *  // ...
+ * }
+ * // throws 'Missing required parameter: bar' if bar is not provided
+ *
+ * @param parameterName Name of required parameter
+ */
+export function required(parameterName: string): never {
+  throw new Error(`Missing required parameter: ${parameterName}`);
+}


### PR DESCRIPTION
#### What?

- Adds tests for each V2 Order endpoint, the `RestClient.ts` class, helper functions in `utils`, as well as for the main RestClient exported from the package
- Fixes bug found in testing for `OrderStatus.ts` where the `getBasePath` function was not able to build an appropriate path if `statusId` was passed as `0` (which is [a valid use case](https://developer.bigcommerce.com/api-reference/b3A6MzU5MDQ3NDE-get-a-single-order-status-by-id))
- Fixes bug found in testing for `paginate.ts` where there was no case to handle `params.page` being passed as a number less than 1
- Includes minor updates to `README.md`

#### Tickets / Documentation

- [APPEX-266](https://jira.bigcommerce.com/browse/APPEX-266)

#### Testing

Run `npm test`

cc @bigcommerce/gta-dt
