### PR TITLE
APPEX-135 adds rate-limiting management

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
   ignorePatterns: ['node_modules', 'dist'],
   rules: {
     'array-callback-return': 'error',
+    'arrow-parens': ['error', 'as-needed'],
     'dot-notation': 'error',
     'guard-for-in': 'error',
     'import/no-absolute-path': 'error',

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  arrowParens: 'avoid',
   printWidth: 120,
   singleQuote: true,
   tabWidth: 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,10 +24,14 @@
         "eslint-plugin-jest": "^26.1.3",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.5.1",
-        "jest-mock-axios": "^4.5.0",
+        "jest-mock-axios": "^4.6.1",
         "prettier": "^2.5.1",
         "ts-jest": "^27.1.4",
         "typescript": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4004,11 +4008,13 @@
       }
     },
     "node_modules/jest-mock-axios": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/jest-mock-axios/-/jest-mock-axios-4.5.0.tgz",
-      "integrity": "sha512-AVrXkFS4psXtuR63J3SFOIpn6VQJHb3khuWJG+yKmSOAvY3jltAkBivV99QTWE+BA6kBYGGUojk6AGE177F8Gw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/jest-mock-axios/-/jest-mock-axios-4.6.1.tgz",
+      "integrity": "sha512-ygTAaOc8N/DGodoJ+JJKP0QLLx12lvYDYgIhrLjFXVGWp5qtQDgtyGq+VciVC2ySdYH8W04y+CTY10qM6BpsjQ==",
       "dev": true,
       "dependencies": {
+        "@jest/globals": "^27.5.1",
+        "jest": "^27.5.1",
         "synchronous-promise": "^2.0.15"
       }
     },
@@ -9058,11 +9064,13 @@
       }
     },
     "jest-mock-axios": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/jest-mock-axios/-/jest-mock-axios-4.5.0.tgz",
-      "integrity": "sha512-AVrXkFS4psXtuR63J3SFOIpn6VQJHb3khuWJG+yKmSOAvY3jltAkBivV99QTWE+BA6kBYGGUojk6AGE177F8Gw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/jest-mock-axios/-/jest-mock-axios-4.6.1.tgz",
+      "integrity": "sha512-ygTAaOc8N/DGodoJ+JJKP0QLLx12lvYDYgIhrLjFXVGWp5qtQDgtyGq+VciVC2ySdYH8W04y+CTY10qM6BpsjQ==",
       "dev": true,
       "requires": {
+        "@jest/globals": "^27.5.1",
+        "jest": "^27.5.1",
         "synchronous-promise": "^2.0.15"
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-jest": "^26.1.3",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.5.1",
-    "jest-mock-axios": "^4.5.0",
+    "jest-mock-axios": "^4.6.1",
     "prettier": "^2.5.1",
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.2"

--- a/src/RateLimitManager/RateLimitManager.spec.ts
+++ b/src/RateLimitManager/RateLimitManager.spec.ts
@@ -1,0 +1,259 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import mockAxios from 'jest-mock-axios';
+
+import { wait } from '../utils/wait';
+
+import RateLimitManager from './index';
+
+const mockClient = mockAxios.create();
+
+jest.mock('../utils/wait', () => ({
+  wait: jest.fn(),
+}));
+
+const headers = {
+  'x-rate-limit-time-reset-ms': '123',
+  'x-rate-limit-time-window-ms': '456',
+  'x-rate-limit-requests-left': '10',
+  'x-rate-limit-requests-quota': '101112',
+};
+
+describe('RateLimitManager', () => {
+  describe('constructor', () => {
+    it('should initialize the rate limit manager', () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 1,
+      });
+
+      expect(rateLimitManager.rateLimitConfig).toEqual({
+        enableWait: true,
+        minRequestsRemaining: 1,
+      });
+      expect(rateLimitManager.status).toBeNull();
+    });
+  });
+
+  describe('setStatus', () => {
+    it('should set the rate limit status from the response headers', () => {
+      const dateSpy = jest.spyOn(global, 'Date'); // spy on Date
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 1,
+      });
+
+      rateLimitManager.setStatus(headers);
+
+      const date = dateSpy.mock.instances[0];
+
+      expect(rateLimitManager.status).toEqual({
+        msToReset: 123,
+        nextWindowTime: date,
+        windowSize: 456,
+        requestsRemaining: 10,
+        requestsQuota: 101112,
+      });
+    });
+  });
+
+  describe('backoff', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should wait until the next rate limit window when remaining requests are less than the minimum', async () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 10,
+      });
+
+      rateLimitManager.setStatus(headers);
+
+      await rateLimitManager.backoff();
+
+      expect(wait).toHaveBeenCalledWith(123);
+    });
+
+    it('should not wait if the rate limit is not enabled', async () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: false,
+        minRequestsRemaining: 1,
+      });
+
+      rateLimitManager.setStatus(headers);
+
+      await rateLimitManager.backoff();
+
+      expect(wait).not.toHaveBeenCalled();
+    });
+
+    it('should not wait if the remaining requests are greater than the minimum', async () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 1,
+      });
+
+      rateLimitManager.setStatus(headers);
+
+      await rateLimitManager.backoff();
+
+      expect(wait).not.toHaveBeenCalled();
+    });
+
+    it('should not wait if status is not set', async () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 1,
+      });
+
+      await rateLimitManager.backoff();
+
+      expect(wait).not.toHaveBeenCalled();
+    });
+
+    it('should run the callback function if provided', async () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 10,
+        callbackParams: { foo: 'bar' },
+        callback: jest.fn(),
+      });
+
+      rateLimitManager.setStatus(headers);
+
+      await rateLimitManager.backoff();
+
+      expect(rateLimitManager.rateLimitConfig.callback).toHaveBeenCalledWith(
+        rateLimitManager.rateLimitConfig.callbackParams,
+      );
+    });
+  });
+
+  describe('requestSuccessInterceptor', () => {
+    it('should call backoff if the rate limit is enabled', async () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 10,
+      });
+
+      rateLimitManager.setStatus(headers);
+
+      const requestConfig = {};
+
+      await rateLimitManager.requestSuccessInterceptor(requestConfig);
+
+      expect(wait).toHaveBeenCalled();
+    });
+  });
+
+  describe('responseSuccessInterceptor', () => {
+    it('should update the rate limit status from the response headers', () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 1,
+      });
+
+      const response = {
+        data: '',
+        status: 200,
+        statusText: 'OK',
+        headers,
+        config: {},
+      };
+
+      rateLimitManager.responseSuccessInterceptor(response);
+
+      expect(rateLimitManager.status).toEqual({
+        msToReset: 123,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        nextWindowTime: expect.any(Date),
+        windowSize: 456,
+        requestsRemaining: 10,
+        requestsQuota: 101112,
+      });
+    });
+  });
+
+  describe('responseErrorInterceptor', () => {
+    it('should throw error for 429 response code', () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 1,
+      });
+
+      const response = {
+        data: '',
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers,
+        config: {},
+      };
+
+      const responseError = {
+        name: 'ResponseError',
+        message: '',
+        config: {},
+        response,
+        isAxiosError: true,
+        toJSON: () => ({}),
+      };
+
+      expect(() => rateLimitManager.responseErrorInterceptor(responseError)).toThrow('Rate limit exceeded');
+    });
+
+    it('should not throw error if response object missing from error', () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 1,
+      });
+
+      const responseError = {
+        name: 'ResponseError',
+        message: '',
+        config: {},
+        isAxiosError: true,
+        toJSON: () => ({}),
+      };
+
+      expect(() => rateLimitManager.responseErrorInterceptor(responseError)).not.toThrow();
+    });
+
+    it('should return error', () => {
+      // @ts-expect-error testing RateLimitManager constructor
+      const rateLimitManager = new RateLimitManager(mockClient, {
+        enableWait: true,
+        minRequestsRemaining: 1,
+      });
+
+      const response = {
+        data: '',
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers,
+        config: {},
+      };
+
+      const responseError = {
+        name: 'ResponseError',
+        message: '',
+        config: {},
+        response,
+        isAxiosError: true,
+        toJSON: () => ({}),
+      };
+
+      expect(rateLimitManager.responseErrorInterceptor(responseError)).toEqual(responseError);
+    });
+  });
+});

--- a/src/RateLimitManager/RateLimitManager.ts
+++ b/src/RateLimitManager/RateLimitManager.ts
@@ -1,0 +1,92 @@
+import { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosResponseHeaders } from 'axios';
+
+import { RateLimitConfig, RateLimitStatus } from '../types';
+import { wait } from '../utils/wait';
+
+class RateLimitManager {
+  private client: AxiosInstance;
+
+  public rateLimitConfig: RateLimitConfig;
+  public status: RateLimitStatus | null;
+
+  constructor(client: AxiosInstance, config: RateLimitConfig) {
+    this.client = client;
+    this.status = null;
+    this.rateLimitConfig = config;
+
+    this.client.interceptors.request.use(this.requestSuccessInterceptor);
+    this.client.interceptors.response.use(this.responseSuccessInterceptor, this.responseErrorInterceptor);
+  }
+
+  /**
+   * Sets the rate limit status from the response headers
+   * @param {AxiosResponseHeaders} headers Headers object from axios response
+   * @returns {void}
+   */
+  public setStatus(headers: AxiosResponseHeaders): void {
+    if (headers['x-rate-limit-time-reset-ms']) {
+      const now = new Date();
+      const msToReset = Number(headers['x-rate-limit-time-reset-ms']);
+      this.status = {
+        msToReset,
+        nextWindowTime: new Date(+now + msToReset),
+        windowSize: Number(headers['x-rate-limit-time-window-ms']),
+        requestsRemaining: Number(headers['x-rate-limit-requests-left']),
+        requestsQuota: Number(headers['x-rate-limit-requests-quota']),
+      };
+    }
+  }
+
+  /**
+   * If enabled, waits until the next rate limit window when remaining requests are less than the minimum. Runs a
+   * callback function if provided in rateLimitConfig.
+   * @returns {Promise<void>}
+   */
+  public async backoff(): Promise<void> {
+    if (this.status) {
+      const isAtRequestThreshold = this.status.requestsRemaining <= this.rateLimitConfig.minRequestsRemaining;
+      if (this.rateLimitConfig.enableWait && isAtRequestThreshold) {
+        await wait(this.status.msToReset);
+      }
+      if (this.rateLimitConfig.callback && isAtRequestThreshold) {
+        this.rateLimitConfig.callback(this.rateLimitConfig.callbackParams);
+      }
+    }
+  }
+
+  /**
+   * Callback passed into client request interceptor for rate limiting management.
+   * @param {AxiosRequestConfig} req Request config object from axios
+   * @returns {Promise<AxiosRequestConfig>} Returns the request config object after backoff runs
+   */
+  public requestSuccessInterceptor = async (req: AxiosRequestConfig): Promise<AxiosRequestConfig> => {
+    await this.backoff();
+
+    return req;
+  };
+
+  /**
+   * Callback to be passed into client response interceptor for rate limiting management.
+   * @param {AxiosResponse} res Response object from axios
+   * @returns {AxiosResponse} Returns the response object after setting the rate limit status
+   */
+  public responseSuccessInterceptor = (res: AxiosResponse): AxiosResponse => {
+    this.setStatus(res.headers);
+
+    return res;
+  };
+
+  /**
+   * Callback to be passed into client response interceptor for better HTTP error handling.
+   * @param {AxiosError} error Error object from axios.
+   */
+  public responseErrorInterceptor = (error: AxiosError): AxiosError => {
+    if (error.response?.status === 429) {
+      throw new Error(`${error.response.status} - Rate limit exceeded. ${this.status?.msToReset ?? 0}ms to reset.`);
+    }
+
+    return error;
+  };
+}
+
+export default RateLimitManager;

--- a/src/RateLimitManager/index.ts
+++ b/src/RateLimitManager/index.ts
@@ -1,0 +1,3 @@
+import RateLimitManager from './RateLimitManager';
+
+export default RateLimitManager;

--- a/src/RestClient/RestClient.spec.ts
+++ b/src/RestClient/RestClient.spec.ts
@@ -2,7 +2,13 @@ import mockAxios from 'jest-mock-axios';
 
 import RestClient from './index';
 
+const mockClient = mockAxios.create();
+
 describe('RestClient', () => {
+  beforeEach(() => {
+    mockAxios.reset();
+  });
+
   describe('constructor', () => {
     it('should throw error for missing storeHash', () => {
       const bigcommerceRest = () =>
@@ -33,6 +39,51 @@ describe('RestClient', () => {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           'X-Auth-Token': config.accessToken,
         },
+      });
+    });
+  });
+
+  describe('interceptors', () => {
+    it('should initilize axios request and response interceptors', () => {
+      new RestClient({
+        storeHash: 'abcdefgh1i',
+        accessToken: '987654321',
+        rateLimitConfig: {
+          enableWait: false,
+          minRequestsRemaining: 16101495,
+        },
+      });
+
+      expect(mockClient.interceptors.request.use).toHaveBeenCalled();
+      expect(mockClient.interceptors.response.use).toHaveBeenCalled();
+    });
+  });
+
+  describe('rateLimitManager', () => {
+    it('should be initialized with the rate limit config', () => {
+      const rateLimitConfig = {
+        enableWait: false,
+        minRequestsRemaining: 16101495,
+      };
+
+      const bigcommerceRest = new RestClient({
+        storeHash: 'abcdefgh1i',
+        accessToken: '987654321',
+        rateLimitConfig,
+      });
+
+      expect(bigcommerceRest.rateLimitManager.rateLimitConfig).toEqual(rateLimitConfig);
+    });
+
+    it('should be initialized with the default rate limit config if not provided', () => {
+      const bigcommerceRest = new RestClient({
+        storeHash: 'abcdefgh1i',
+        accessToken: '987654321',
+      });
+
+      expect(bigcommerceRest.rateLimitManager.rateLimitConfig).toEqual({
+        enableWait: false,
+        minRequestsRemaining: 1,
       });
     });
   });

--- a/src/RestClient/RestClient.ts
+++ b/src/RestClient/RestClient.ts
@@ -1,11 +1,13 @@
 import axios from 'axios';
 
+import RateLimitManager from '../RateLimitManager';
 import { RestClientConfig } from '../types';
 
 import OrdersV2 from './endpoints/Orders/v2';
 
 class RestClient {
   public ordersV2: OrdersV2;
+  public rateLimitManager: RateLimitManager;
 
   constructor(config: RestClientConfig) {
     if (!config.storeHash || !config.accessToken) {
@@ -22,6 +24,10 @@ class RestClient {
       },
     });
 
+    this.rateLimitManager = new RateLimitManager(
+      client,
+      config.rateLimitConfig ?? { enableWait: false, minRequestsRemaining: 1 },
+    );
     this.ordersV2 = new OrdersV2(client);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,26 @@ export interface RestClientConfig {
   storeHash: string;
   accessToken: string;
   apiHost?: string;
+  rateLimitConfig?: RateLimitConfig;
+}
+
+export interface RateLimitStatus {
+  msToReset: number;
+  nextWindowTime: Date;
+  windowSize: number;
+  requestsRemaining: number;
+  requestsQuota: number;
+}
+
+type CallbackParams = {
+  [key: string]: unknown;
+};
+
+export interface RateLimitConfig {
+  minRequestsRemaining: number;
+  enableWait: boolean;
+  callbackParams?: CallbackParams;
+  callback?(params?: CallbackParams): void;
 }
 
 export interface AuthCallbackQueryParams {

--- a/src/utils/paginate.spec.ts
+++ b/src/utils/paginate.spec.ts
@@ -4,7 +4,7 @@ const mockList = jest.fn();
 
 beforeEach(() => {
   mockList.mockReturnValueOnce(
-    new Promise((resolve) =>
+    new Promise(resolve =>
       resolve({
         data: [{ id: 1 }, { id: 2 }],
       }),
@@ -12,7 +12,7 @@ beforeEach(() => {
   );
 
   mockList.mockReturnValueOnce(
-    new Promise((resolve) =>
+    new Promise(resolve =>
       resolve({
         data: [{ id: 3 }, { id: 4 }],
       }),
@@ -20,7 +20,7 @@ beforeEach(() => {
   );
 
   mockList.mockReturnValueOnce(
-    new Promise((resolve) =>
+    new Promise(resolve =>
       resolve({
         data: [],
       }),

--- a/src/utils/wait.spec.ts
+++ b/src/utils/wait.spec.ts
@@ -1,0 +1,10 @@
+import { wait } from './wait';
+
+describe('wait', () => {
+  it('should wait for a given amount of time', async () => {
+    const start = Date.now();
+    await wait(100);
+    const end = Date.now();
+    expect(end - start).toBeGreaterThanOrEqual(100);
+  });
+});

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -1,0 +1,3 @@
+export function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
#### What?

Adds rate-limiting management where developers can configure a threshold at which they'd like to start delaying requests until the next window or run a custom callback function. Uses Axios interceptors to update rate-limit data coming from response headers and hold requests for the duration of the window. 

Also fixes the `arrow-parens` eslint rule adding unnecessary parenthesis to single-argument arrow functions.

#### Tickets / Documentation

-   [APPEX-135](https://jira.bigcommerce.com/browse/APPEX-135)
-   ...

#### Testing

- Adds unit test for `wait` function as well as `RateLimitManager` methods.
- Automated testing for axios interceptors initialization. 

cc @bigcommerce/gta-dt
