### PR TITLE
fix: APPEX-585 udpate catalog typing

### DIFF
--- a/src/RestClient/endpoints/V3/Catalog/types.ts
+++ b/src/RestClient/endpoints/V3/Catalog/types.ts
@@ -1,300 +1,426 @@
-import { operations } from '../../../../generate/generated/catalog.v3';
+import { operations as brandOperations } from '../../../../generate/generated/brands_catalog.v3';
+import { operations as categoriesOperations } from '../../../../generate/generated/categories_catalog.v3';
+import { operations as categoriesTreeOperations } from '../../../../generate/generated/category-trees_catalog.v3';
+import { operations as productModifiersOperations } from '../../../../generate/generated/product-modifiers_catalog.v3';
+import { operations as productVariantOptionsOperations } from '../../../../generate/generated/product-variant-options_catalog.v3';
+import { operations as productVariantsOperations } from '../../../../generate/generated/product-variants_catalog.v3';
+import { operations as productsOperations } from '../../../../generate/generated/products_catalog.v3';
 import { AxiosPromise } from '../../../../types';
 
 export interface BrandImage {
-  CreateResponse: AxiosPromise<operations['createBrandImage']['responses']['200']['content']['application/json']>;
+  CreateResponse: AxiosPromise<brandOperations['createBrandImage']['responses']['200']['content']['application/json']>;
 }
 
 export interface BrandMetafield {
-  ListFilters: operations['getBrandMetafieldsByBrandId']['parameters']['query'];
+  ListFilters: brandOperations['getBrandMetafieldsByBrandId']['parameters']['query'];
   ListResponse: AxiosPromise<
-    operations['getBrandMetafieldsByBrandId']['responses']['200']['content']['application/json']
+    brandOperations['getBrandMetafieldsByBrandId']['responses']['200']['content']['application/json']
   >;
-  CreateRequest: operations['createBrandMetafield']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createBrandMetafield']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getBrandMetafieldsByBrandId']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getBrandMetafieldsByBrandId']['parameters']['query']>;
-  UpdateRequest: operations['updateBrandMetafield']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateBrandMetafield']['responses']['200']['content']['application/json']>;
+  CreateRequest: brandOperations['createBrandMetafield']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    brandOperations['createBrandMetafield']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: brandOperations['getBrandMetafieldsByBrandId']['parameters']['query'];
+  GetResponse: AxiosPromise<brandOperations['getBrandMetafieldsByBrandId']['parameters']['query']>;
+  UpdateRequest: brandOperations['updateBrandMetafield']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    brandOperations['updateBrandMetafield']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface Brand {
-  ListFilters: operations['getBrands']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getBrands']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createBrand']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createBrand']['responses']['200']['content']['application/json']>;
-  DeleteManyFilters: operations['deleteBrands']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getBrandById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateBrand']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateBrand']['responses']['200']['content']['application/json']>;
+  ListFilters: brandOperations['getBrands']['parameters']['query'];
+  ListResponse: AxiosPromise<brandOperations['getBrands']['responses']['200']['content']['application/json']>;
+  CreateRequest: brandOperations['createBrand']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<brandOperations['createBrand']['responses']['200']['content']['application/json']>;
+  DeleteManyFilters: brandOperations['deleteBrands']['parameters']['query'];
+  GetResponse: AxiosPromise<brandOperations['getBrandById']['responses']['200']['content']['application/json']>;
+  UpdateRequest: brandOperations['updateBrand']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<brandOperations['updateBrand']['responses']['200']['content']['application/json']>;
 }
 
 export interface CategoryBatch {
-  ListFilters: operations['getAllCategories']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getAllCategories']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createCategories']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createCategories']['responses']['201']['content']['application/json']>;
-  UpdateRequest: operations['updateCategories']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateCategories']['responses']['204']['content']['application/json']>;
-  DeleteFilters: operations['deleteTreeCategories']['parameters']['query'];
-  DeleteResponse: AxiosPromise<operations['deleteTreeCategories']['responses']['204']['content']['application/json']>;
+  ListFilters: categoriesTreeOperations['getAllCategories']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    categoriesTreeOperations['getAllCategories']['responses']['200']['content']['application/json']
+  >;
+  CreateRequest: categoriesTreeOperations['createCategories']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    categoriesTreeOperations['createCategories']['responses']['201']['content']['application/json']
+  >;
+  UpdateRequest: categoriesTreeOperations['updateCategories']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    categoriesTreeOperations['updateCategories']['responses']['204']['content']['application/json']
+  >;
+  DeleteFilters: categoriesTreeOperations['deleteTreeCategories']['parameters']['query'];
+  DeleteResponse: AxiosPromise<
+    categoriesTreeOperations['deleteTreeCategories']['responses']['204']['content']['application/json']
+  >;
 }
 
 export interface Categories {
-  ListFilters: operations['getCategories']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getCategories']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createCategory']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createCategory']['responses']['200']['content']['application/json']>;
-  DeleteManyFilters: operations['deleteCategories']['parameters']['query'];
-  GetFilters: operations['getCategoryById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getCategoryById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateCategory']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateCategory']['responses']['200']['content']['application/json']>;
+  ListFilters: categoriesOperations['getCategories']['parameters']['query'];
+  ListResponse: AxiosPromise<categoriesOperations['getCategories']['responses']['200']['content']['application/json']>;
+  CreateRequest: categoriesOperations['createCategory']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    categoriesOperations['createCategory']['responses']['200']['content']['application/json']
+  >;
+  DeleteManyFilters: categoriesOperations['deleteCategories']['parameters']['query'];
+  GetFilters: categoriesOperations['getCategoryById']['parameters']['query'];
+  GetResponse: AxiosPromise<categoriesOperations['getCategoryById']['responses']['200']['content']['application/json']>;
+  UpdateRequest: categoriesOperations['updateCategory']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    categoriesOperations['updateCategory']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface CategoryImage {
-  CreateResponse: AxiosPromise<operations['createCategoryImage']['responses']['200']['content']['application/json']>;
+  CreateResponse: AxiosPromise<
+    categoriesOperations['createCategoryImage']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface CategoryMetafield {
-  ListFilters: operations['getCategoryMetafieldsByCategoryId']['parameters']['query'];
+  ListFilters: categoriesOperations['getCategoryMetafieldsByCategoryId']['parameters']['query'];
   ListResponse: AxiosPromise<
-    operations['getCategoryMetafieldsByCategoryId']['responses']['200']['content']['application/json']
+    categoriesOperations['getCategoryMetafieldsByCategoryId']['responses']['200']['content']['application/json']
   >;
-  CreateRequest: operations['createCategoryMetafield']['requestBody']['content']['application/json'];
+  CreateRequest: categoriesOperations['createCategoryMetafield']['requestBody']['content']['application/json'];
   CreateResponse: AxiosPromise<
-    operations['createCategoryMetafield']['responses']['200']['content']['application/json']
+    categoriesOperations['createCategoryMetafield']['responses']['200']['content']['application/json']
   >;
-  GetFilters: operations['getCategoryMetafieldByCategoryId']['parameters']['query'];
+  GetFilters: categoriesOperations['getCategoryMetafieldByCategoryId']['parameters']['query'];
   GetResponse: AxiosPromise<
-    operations['getCategoryMetafieldByCategoryId']['responses']['200']['content']['application/json']
+    categoriesOperations['getCategoryMetafieldByCategoryId']['responses']['200']['content']['application/json']
   >;
-  UpdateRequest: operations['updateCategoryMetafield']['requestBody']['content']['application/json'];
+  UpdateRequest: categoriesOperations['updateCategoryMetafield']['requestBody']['content']['application/json'];
   UpdateResponse: AxiosPromise<
-    operations['updateCategoryMetafield']['responses']['200']['content']['application/json']
+    categoriesOperations['updateCategoryMetafield']['responses']['200']['content']['application/json']
   >;
 }
 
 export interface CategoryTree {
-  ListFilters: operations['GetCategoryTrees']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['GetCategoryTrees']['responses']['200']['content']['application/json']>;
-  UpsertRequest: operations['UpsertCategoryTrees']['requestBody']['content']['application/json'];
-  UpsertResponse: AxiosPromise<operations['UpsertCategoryTrees']['responses']['200']['content']['application/json']>;
-  DeleteFilters: operations['DeleteCategoryTrees']['parameters']['query'];
-  GetFilters: operations['GetCategoryTreeByTreeId']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['GetCategoryTreeByTreeId']['responses']['200']['content']['application/json']>;
+  ListFilters: categoriesTreeOperations['GetCategoryTrees']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    categoriesTreeOperations['GetCategoryTrees']['responses']['200']['content']['application/json']
+  >;
+  UpsertRequest: categoriesTreeOperations['UpsertCategoryTrees']['requestBody']['content']['application/json'];
+  UpsertResponse: AxiosPromise<
+    categoriesTreeOperations['UpsertCategoryTrees']['responses']['200']['content']['application/json']
+  >;
+  DeleteFilters: categoriesTreeOperations['DeleteCategoryTrees']['parameters']['query'];
+  GetFilters: categoriesTreeOperations['GetCategoryTreeByTreeId']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    categoriesTreeOperations['GetCategoryTreeByTreeId']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductBulkPricingRule {
-  ListFilters: operations['getBulkPricingRules']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getBulkPricingRules']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createBulkPricingRule']['requestBody']['content']['application/json'];
-  CreateFilters: operations['createBulkPricingRule']['parameters']['query'];
-  CreateResponse: AxiosPromise<operations['createBulkPricingRule']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getBulkPricingRuleById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getBulkPricingRuleById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateBulkPricingRule']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateBulkPricingRule']['responses']['200']['content']['application/json']>;
+  ListFilters: productsOperations['getBulkPricingRules']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    productsOperations['getBulkPricingRules']['responses']['200']['content']['application/json']
+  >;
+  CreateRequest: productsOperations['createBulkPricingRule']['requestBody']['content']['application/json'];
+  CreateFilters: productsOperations['createBulkPricingRule']['parameters']['query'];
+  CreateResponse: AxiosPromise<
+    productsOperations['createBulkPricingRule']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productsOperations['getBulkPricingRuleById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productsOperations['getBulkPricingRuleById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productsOperations['updateBulkPricingRule']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productsOperations['updateBulkPricingRule']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductComplexRule {
-  ListFilters: operations['getComplexRules']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getComplexRules']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createComplexRule']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createComplexRule']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getComplexRuleById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getComplexRuleById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateComplexRule']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateComplexRule']['responses']['200']['content']['application/json']>;
+  ListFilters: productsOperations['getComplexRules']['parameters']['query'];
+  ListResponse: AxiosPromise<productsOperations['getComplexRules']['responses']['200']['content']['application/json']>;
+  CreateRequest: productsOperations['createComplexRule']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productsOperations['createComplexRule']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productsOperations['getComplexRuleById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productsOperations['getComplexRuleById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productsOperations['updateComplexRule']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productsOperations['updateComplexRule']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductCustomField {
-  ListFilters: operations['getCustomFields']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getCustomFields']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createCustomField']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createCustomField']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getCustomFieldById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getCustomFieldById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateCustomField']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateCustomField']['responses']['200']['content']['application/json']>;
+  ListFilters: productsOperations['getCustomFields']['parameters']['query'];
+  ListResponse: AxiosPromise<productsOperations['getCustomFields']['responses']['200']['content']['application/json']>;
+  CreateRequest: productsOperations['createCustomField']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productsOperations['createCustomField']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productsOperations['getCustomFieldById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productsOperations['getCustomFieldById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productsOperations['updateCustomField']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productsOperations['updateCustomField']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductImage {
-  ListFilters: operations['getProductImages']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getProductImages']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createProductImage']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createProductImage']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getProductImageById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getProductImageById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateProductImage']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateProductImage']['responses']['200']['content']['application/json']>;
+  ListFilters: productsOperations['getProductImages']['parameters']['query'];
+  ListResponse: AxiosPromise<productsOperations['getProductImages']['responses']['200']['content']['application/json']>;
+  CreateRequest: productsOperations['createProductImage']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productsOperations['createProductImage']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productsOperations['getProductImageById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productsOperations['getProductImageById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productsOperations['updateProductImage']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productsOperations['updateProductImage']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductMetafield {
-  ListFilters: operations['getProductMetafieldsByProductId']['parameters']['query'];
+  ListFilters: productsOperations['getProductMetafieldsByProductId']['parameters']['query'];
   ListResponse: AxiosPromise<
-    operations['getProductMetafieldsByProductId']['responses']['200']['content']['application/json']
+    productsOperations['getProductMetafieldsByProductId']['responses']['200']['content']['application/json']
   >;
-  CreateRequest: operations['createProductMetafield']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createProductMetafield']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getProductMetafieldByProductId']['parameters']['query'];
+  CreateRequest: productsOperations['createProductMetafield']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productsOperations['createProductMetafield']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productsOperations['getProductMetafieldByProductId']['parameters']['query'];
   GetResponse: AxiosPromise<
-    operations['getProductMetafieldByProductId']['responses']['200']['content']['application/json']
+    productsOperations['getProductMetafieldByProductId']['responses']['200']['content']['application/json']
   >;
-  UpdateRequest: operations['updateProductMetafield']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateProductMetafield']['responses']['200']['content']['application/json']>;
+  UpdateRequest: productsOperations['updateProductMetafield']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productsOperations['updateProductMetafield']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductModifierImage {
-  CreateResponse: AxiosPromise<operations['createModifierImage']['responses']['200']['content']['application/json']>;
+  CreateResponse: AxiosPromise<
+    productModifiersOperations['createModifierImage']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductModifier {
-  ListFilters: operations['getModifiers']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getModifiers']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createModifier']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createModifier']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getModifierById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getModifierById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateModifier']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateModifier']['responses']['200']['content']['application/json']>;
+  ListFilters: productModifiersOperations['getModifiers']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    productModifiersOperations['getModifiers']['responses']['200']['content']['application/json']
+  >;
+  CreateRequest: productModifiersOperations['createModifier']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productModifiersOperations['createModifier']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productModifiersOperations['getModifierById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productModifiersOperations['getModifierById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productModifiersOperations['updateModifier']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productModifiersOperations['updateModifier']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductModifierValue {
-  ListFilters: operations['getModifierValues']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getModifierValues']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createModifierValue']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createModifierValue']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getModifierValueById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getModifierValueById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateModifierValue']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateModifierValue']['responses']['200']['content']['application/json']>;
+  ListFilters: productModifiersOperations['getModifierValues']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    productModifiersOperations['getModifierValues']['responses']['200']['content']['application/json']
+  >;
+  CreateRequest: productModifiersOperations['createModifierValue']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productModifiersOperations['createModifierValue']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productModifiersOperations['getModifierValueById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productModifiersOperations['getModifierValueById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productModifiersOperations['updateModifierValue']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productModifiersOperations['updateModifierValue']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductReview {
-  ListFilters: operations['getProductReviews']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getProductReviews']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createProductReview']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createProductReview']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getProductReviewById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getProductReviewById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateProductReview']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateProductReview']['responses']['200']['content']['application/json']>;
+  ListFilters: productsOperations['getProductReviews']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    productsOperations['getProductReviews']['responses']['200']['content']['application/json']
+  >;
+  CreateRequest: productsOperations['createProductReview']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productsOperations['createProductReview']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productsOperations['getProductReviewById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productsOperations['getProductReviewById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productsOperations['updateProductReview']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productsOperations['updateProductReview']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface CategoryAssignments {
-  ListFilters: operations['GetProductsCategoryAssignments']['parameters']['query'];
+  ListFilters: productsOperations['GetProductsCategoryAssignments']['parameters']['query'];
   ListResponse: AxiosPromise<
-    operations['GetProductsCategoryAssignments']['responses']['200']['content']['application/json']
+    productsOperations['GetProductsCategoryAssignments']['responses']['200']['content']['application/json']
   >;
-  CreateRequest: operations['CreateProductsCategoryAssignments']['requestBody']['content']['application/json'];
-  DeleteFilters: operations['DeleteProductsCategoryAssignments']['parameters']['query'];
+  CreateRequest: productsOperations['CreateProductsCategoryAssignments']['requestBody']['content']['application/json'];
+  DeleteFilters: productsOperations['DeleteProductsCategoryAssignments']['parameters']['query'];
 }
 
 export interface ChannelAssignments {
-  ListFilters: operations['GetProductsChannelAssignments']['parameters']['query'];
+  ListFilters: productsOperations['GetProductsChannelAssignments']['parameters']['query'];
   ListResponse: AxiosPromise<
-    operations['GetProductsChannelAssignments']['responses']['200']['content']['application/json']
+    productsOperations['GetProductsChannelAssignments']['responses']['200']['content']['application/json']
   >;
-  CreateRequest: operations['CreateProductsChannelAssignments']['requestBody']['content']['application/json'];
-  DeleteFilters: operations['DeleteProductsChannelAssignments']['parameters']['query'];
+  CreateRequest: productsOperations['CreateProductsChannelAssignments']['requestBody']['content']['application/json'];
+  DeleteFilters: productsOperations['DeleteProductsChannelAssignments']['parameters']['query'];
 }
 
 export interface SortOrder {
-  ListResponse: AxiosPromise<operations['getsortorders']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updatesortorder']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updatesortorder']['responses']['200']['content']['application/json']>;
+  ListResponse: AxiosPromise<categoriesOperations['getsortorders']['responses']['200']['content']['application/json']>;
+  UpdateRequest: categoriesOperations['updatesortorder']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    categoriesOperations['updatesortorder']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface VariantOptions {
-  ListFilters: operations['getOptions']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getOptions']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createOption']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createOption']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getOptionById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getOptionById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateOption']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateOption']['responses']['200']['content']['application/json']>;
+  ListFilters: productVariantOptionsOperations['getOptions']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    productVariantOptionsOperations['getOptions']['responses']['200']['content']['application/json']
+  >;
+  CreateRequest: productVariantOptionsOperations['createOption']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productVariantOptionsOperations['createOption']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productVariantOptionsOperations['getOptionById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productVariantOptionsOperations['getOptionById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productVariantOptionsOperations['updateOption']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productVariantOptionsOperations['updateOption']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface VariantOptionValues {
-  ListFilters: operations['getOptionValues']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getOptionValues']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createOptionValue']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createOptionValue']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getOptionValueById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getOptionValueById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateOptionValue']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateOptionValue']['responses']['200']['content']['application/json']>;
+  ListFilters: productVariantOptionsOperations['getOptionValues']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    productVariantOptionsOperations['getOptionValues']['responses']['200']['content']['application/json']
+  >;
+  CreateRequest: productVariantOptionsOperations['createOptionValue']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productVariantOptionsOperations['createOptionValue']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productVariantOptionsOperations['getOptionValueById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productVariantOptionsOperations['getOptionValueById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productVariantOptionsOperations['updateOptionValue']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productVariantOptionsOperations['updateOptionValue']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface ProductVariant {
-  ListFilters: operations['getVariantsByProductId']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getVariantsByProductId']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createVariant']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createVariant']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getVariantById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getVariantById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateVariant']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateVariant']['responses']['200']['content']['application/json']>;
-  CreateImageRequest: operations['createVariantImage']['requestBody']['content']['application/json'];
+  ListFilters: productVariantsOperations['getVariantsByProductId']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    productVariantsOperations['getVariantsByProductId']['responses']['200']['content']['application/json']
+  >;
+  CreateRequest: productVariantsOperations['createVariant']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productVariantsOperations['createVariant']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productVariantsOperations['getVariantById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productVariantsOperations['getVariantById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productVariantsOperations['updateVariant']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productVariantsOperations['updateVariant']['responses']['200']['content']['application/json']
+  >;
+  CreateImageRequest: productVariantsOperations['createVariantImage']['requestBody']['content']['application/json'];
   CreateImageResponse: AxiosPromise<
-    operations['createVariantImage']['responses']['200']['content']['application/json']
+    productVariantsOperations['createVariantImage']['responses']['200']['content']['application/json']
   >;
 }
 
 export interface VariantMetafields {
-  ListFilters: operations['getVariantMetafieldsByProductIdAndVariantId']['parameters']['query'];
+  ListFilters: productVariantsOperations['getVariantMetafieldsByProductIdAndVariantId']['parameters']['query'];
   ListResponse: AxiosPromise<
-    operations['getVariantMetafieldsByProductIdAndVariantId']['responses']['200']['content']['application/json']
+    productVariantsOperations['getVariantMetafieldsByProductIdAndVariantId']['responses']['200']['content']['application/json']
   >;
-  CreateRequest: operations['createVariantMetafield']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createVariantMetafield']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getVariantMetafieldByProductIdAndVariantId']['parameters']['query'];
+  CreateRequest: productVariantsOperations['createVariantMetafield']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productVariantsOperations['createVariantMetafield']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productVariantsOperations['getVariantMetafieldByProductIdAndVariantId']['parameters']['query'];
   GetResponse: AxiosPromise<
-    operations['getVariantMetafieldByProductIdAndVariantId']['responses']['200']['content']['application/json']
+    productVariantsOperations['getVariantMetafieldByProductIdAndVariantId']['responses']['200']['content']['application/json']
   >;
-  UpdateRequest: operations['updateVariantMetafield']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateVariantMetafield']['responses']['200']['content']['application/json']>;
+  UpdateRequest: productVariantsOperations['updateVariantMetafield']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productVariantsOperations['updateVariantMetafield']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface Videos {
-  ListFilters: operations['getProductVideos']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getProductVideos']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createProductVideo']['requestBody']['content']['application/json'];
-  CreateResponse: AxiosPromise<operations['createProductVideo']['responses']['200']['content']['application/json']>;
-  GetFilters: operations['getProductVideoById']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getProductVideoById']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateProductVideo']['requestBody']['content']['application/json'];
-  UpdateResponse: AxiosPromise<operations['updateProductVideo']['responses']['200']['content']['application/json']>;
+  ListFilters: productsOperations['getProductVideos']['parameters']['query'];
+  ListResponse: AxiosPromise<productsOperations['getProductVideos']['responses']['200']['content']['application/json']>;
+  CreateRequest: productsOperations['createProductVideo']['requestBody']['content']['application/json'];
+  CreateResponse: AxiosPromise<
+    productsOperations['createProductVideo']['responses']['200']['content']['application/json']
+  >;
+  GetFilters: productsOperations['getProductVideoById']['parameters']['query'];
+  GetResponse: AxiosPromise<
+    productsOperations['getProductVideoById']['responses']['200']['content']['application/json']
+  >;
+  UpdateRequest: productsOperations['updateProductVideo']['requestBody']['content']['application/json'];
+  UpdateResponse: AxiosPromise<
+    productsOperations['updateProductVideo']['responses']['200']['content']['application/json']
+  >;
 }
 
 export interface CatSummary {
-  GetResponse: AxiosPromise<operations['getCatalogSummary']['responses']['200']['content']['application/json']>;
+  GetResponse: AxiosPromise<productsOperations['getCatalogSummary']['responses']['200']['content']['application/json']>;
 }
 
 export interface Variant {
-  ListFilters: operations['getVariants']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getVariants']['responses']['200']['content']['application/json']>;
-  UpdateBatchRequest: operations['updateVariantsBatch']['requestBody']['content']['application/json'];
+  ListFilters: productVariantsOperations['getVariants']['parameters']['query'];
+  ListResponse: AxiosPromise<
+    productVariantsOperations['getVariants']['responses']['200']['content']['application/json']
+  >;
+  UpdateBatchRequest: productVariantsOperations['updateVariantsBatch']['requestBody']['content']['application/json'];
   UpdateBatchResponse: AxiosPromise<
-    operations['updateVariantsBatch']['responses']['200']['content']['application/json']
+    productVariantsOperations['updateVariantsBatch']['responses']['200']['content']['application/json']
   >;
 }
 
 export interface Product {
-  ListFilters: operations['getProducts']['parameters']['query'];
-  ListResponse: AxiosPromise<operations['getProducts']['responses']['200']['content']['application/json']>;
-  UpdateBatchRequest: operations['updateProducts']['requestBody']['content']['application/json'];
-  UpdateBatchFilters: operations['updateProducts']['parameters']['query'];
-  UpdateBatchResponse: AxiosPromise<operations['updateProducts']['responses']['200']['content']['application/json']>;
-  CreateRequest: operations['createProduct']['requestBody']['content']['application/json'];
-  CreateFilters: operations['createProduct']['parameters']['query'];
-  CreateResponse: AxiosPromise<operations['createProduct']['responses']['200']['content']['application/json']>;
-  DeleteManyFilters: operations['deleteProducts']['parameters']['query'];
-  GetFilters: operations['getProducts']['parameters']['query'];
-  GetResponse: AxiosPromise<operations['getProducts']['responses']['200']['content']['application/json']>;
-  UpdateRequest: operations['updateProducts']['requestBody']['content']['application/json'];
-  UpdateFilters: operations['updateProducts']['parameters']['query'];
-  UpdateResponse: AxiosPromise<operations['updateProducts']['responses']['200']['content']['application/json']>;
+  ListFilters: productsOperations['getProducts']['parameters']['query'];
+  ListResponse: AxiosPromise<productsOperations['getProducts']['responses']['200']['content']['application/json']>;
+  UpdateBatchRequest: productsOperations['updateProducts']['requestBody']['content']['application/json'];
+  UpdateBatchFilters: productsOperations['updateProducts']['parameters']['query'];
+  UpdateBatchResponse: AxiosPromise<
+    productsOperations['updateProducts']['responses']['200']['content']['application/json']
+  >;
+  CreateRequest: productsOperations['createProduct']['requestBody']['content']['application/json'];
+  CreateFilters: productsOperations['createProduct']['parameters']['query'];
+  CreateResponse: AxiosPromise<productsOperations['createProduct']['responses']['200']['content']['application/json']>;
+  DeleteManyFilters: productsOperations['deleteProducts']['parameters']['query'];
+  GetFilters: productsOperations['getProducts']['parameters']['query'];
+  GetResponse: AxiosPromise<productsOperations['getProducts']['responses']['200']['content']['application/json']>;
+  UpdateRequest: productsOperations['updateProducts']['requestBody']['content']['application/json'];
+  UpdateFilters: productsOperations['updateProducts']['parameters']['query'];
+  UpdateResponse: AxiosPromise<productsOperations['updateProducts']['responses']['200']['content']['application/json']>;
 }

--- a/src/generate/TypesGenerator.spec.ts
+++ b/src/generate/TypesGenerator.spec.ts
@@ -132,8 +132,8 @@ describe('TypesGenerator', () => {
 
       void (await tg.generate());
 
-      void expect(openapiTS).toBeCalledTimes(2);
-      void expect(promises.writeFile).toBeCalledTimes(2);
+      expect(openapiTS).toBeCalledTimes(2);
+      expect(promises.writeFile).toBeCalledTimes(2);
     });
 
     it('should generate a Typescript file for each spec file and/or dir', async () => {
@@ -187,8 +187,8 @@ describe('TypesGenerator', () => {
 
       void (await tg.generate());
 
-      void expect(openapiTS).toBeCalledTimes(3);
-      void expect(promises.writeFile).toBeCalledTimes(3);
+      expect(openapiTS).toBeCalledTimes(3);
+      expect(promises.writeFile).toBeCalledTimes(3);
     });
   });
 });

--- a/src/generate/TypesGenerator.spec.ts
+++ b/src/generate/TypesGenerator.spec.ts
@@ -68,6 +68,7 @@ describe('TypesGenerator', () => {
         data: {
           tree: [
             {
+              type: 'blob',
               path: 'reference',
               url: 'https://api.github.com/repos/bigcommerce/api-specs/trees/12345',
             },
@@ -79,9 +80,11 @@ describe('TypesGenerator', () => {
         data: {
           tree: [
             {
+              type: 'blob',
               path: 'foo-spec.yaml',
             },
             {
+              type: 'blob',
               path: 'bar-spec.yml',
             },
           ],
@@ -102,6 +105,7 @@ describe('TypesGenerator', () => {
         data: {
           tree: [
             {
+              type: 'blob',
               path: 'reference',
               url: 'https://api.github.com/repos/bigcommerce/api-specs/trees/12345',
             },
@@ -113,9 +117,11 @@ describe('TypesGenerator', () => {
         data: {
           tree: [
             {
+              type: 'blob',
               path: 'foo-spec.yaml',
             },
             {
+              type: 'blob',
               path: 'bar-spec.yml',
             },
           ],
@@ -128,6 +134,61 @@ describe('TypesGenerator', () => {
 
       void expect(openapiTS).toBeCalledTimes(2);
       void expect(promises.writeFile).toBeCalledTimes(2);
+    });
+
+    it('should generate a Typescript file for each spec file and/or dir', async () => {
+      const mockFirstResponse = {
+        data: {
+          tree: [
+            {
+              type: 'blob',
+              path: 'reference',
+              url: 'https://api.github.com/repos/bigcommerce/api-specs/trees/12345',
+            },
+          ],
+        },
+      };
+
+      const mockSecondResponse = {
+        data: {
+          tree: [
+            {
+              type: 'blob',
+              path: 'foo-spec.yaml',
+            },
+            {
+              type: 'blob',
+              path: 'bar-spec.yml',
+            },
+            {
+              type: 'tree',
+              path: 'catalog',
+              url: 'https://api.github.com/repos/bigcommerce/api-specs/trees/123456',
+            },
+          ],
+        },
+      };
+
+      const mockThirdResponse = {
+        data: {
+          tree: [
+            {
+              type: 'blob',
+              path: 'categories-catalog.yml',
+            },
+          ],
+        },
+      };
+
+      mockAxios.get
+        .mockResolvedValueOnce(mockFirstResponse)
+        .mockResolvedValueOnce(mockSecondResponse)
+        .mockResolvedValueOnce(mockThirdResponse);
+
+      void (await tg.generate());
+
+      void expect(openapiTS).toBeCalledTimes(3);
+      void expect(promises.writeFile).toBeCalledTimes(3);
     });
   });
 });

--- a/src/generate/TypesGenerator.ts
+++ b/src/generate/TypesGenerator.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { assertIsError } from '../utils/assertIsError';
 
-import { GitHubRepoTree } from './types';
+import { GitHubRepoTree, NestedTree } from './types';
 
 const { writeFile } = promises;
 
@@ -14,6 +14,7 @@ class TypesGenerator {
 
   private REPO_URL = 'https://api.github.com/repos/bigcommerce/api-specs/git/trees/main';
   private CONTENT_URL = 'https://raw.githubusercontent.com/bigcommerce/api-specs/main/reference/';
+  // private CONTENT_URL = 'https://raw.githubusercontent.com/bigcommerce/api-specs/main';
 
   private OUTPUT_DIRECTORY_PATH = path.join(process.cwd(), 'src/generate/generated');
   private PRETTIER_CONFIG_PATH = path.join(process.cwd(), '.prettierrc');
@@ -32,6 +33,8 @@ class TypesGenerator {
    */
   public async generate(): Promise<void> {
     const sourceFiles = await this.getSourceFiles();
+
+    // console.log(sourceFiles, 'here the source files');
 
     for (const sourceFile of sourceFiles) {
       const outputPath = path.join(
@@ -63,14 +66,49 @@ class TypesGenerator {
    */
   private async getSourceFiles(): Promise<string[]> {
     const sourceRepo = await this.client.get<GitHubRepoTree>(this.REPO_URL);
+    // console.log(sourceRepo, 'here the source repo');
+
+    // console.log(sourceRepo.data.tree, 'here the tree');
     const targetDir = sourceRepo.data.tree.find(file => file.path === 'reference');
+    // // console.log(targetDir, 'here teh targetDir');
+    // const targetDir = sourceRepo.data.tree.
+    // console.log(targetDir, 'here the target DIR');
 
     if (!targetDir) {
       throw new Error('Unable to find a directory containing Open API spec files in provided repo');
     }
 
+    const specFileNames = await this.getSpecFileNames(targetDir);
+
+    // const remoteSourceDir = await this.client.get<GitHubRepoTree>(targetDir.url);
+    // const specFileNames = remoteSourceDir.data.tree.map(file => `${this.CONTENT_URL}${file.path}`);
+
+    return specFileNames;
+  }
+
+  private async getSpecFileNames(targetDir?: NestedTree): Promise<string[]> {
+    if (!targetDir) {
+      return [];
+    }
+
     const remoteSourceDir = await this.client.get<GitHubRepoTree>(targetDir.url);
-    const specFileNames = remoteSourceDir.data.tree.map(file => `${this.CONTENT_URL}${file.path}`);
+
+    const specFileNames = await remoteSourceDir.data.tree.reduce(
+      async (accPromise: Promise<string[]>, node: NestedTree): Promise<string[]> => {
+        const acc = await accPromise;
+
+        if (node.type === 'blob') {
+          return targetDir.path === 'reference'
+            ? [...acc, `${this.CONTENT_URL}${node.path}`]
+            : [...acc, `${this.CONTENT_URL}${targetDir.path}/${node.path}`];
+        } else {
+          const nestedSpecFileNames: string[] = await this.getSpecFileNames(node);
+
+          return [...acc, ...nestedSpecFileNames];
+        }
+      },
+      Promise.resolve([]),
+    );
 
     return specFileNames;
   }

--- a/src/generate/TypesGenerator.ts
+++ b/src/generate/TypesGenerator.ts
@@ -69,9 +69,7 @@ class TypesGenerator {
       throw new Error('Unable to find a directory containing Open API spec files in provided repo');
     }
 
-    const specFileNames = await this.getSpecFileNames('reference', targetDir);
-
-    return specFileNames;
+    return await this.getSpecFileNames('reference', targetDir);
   }
 
   /**


### PR DESCRIPTION
#### What?
The [Node API client](https://github.com/bigcommerce/bigcommerce-api-node/tree/main) is [broken](https://github.com/bigcommerce/bigcommerce-api-node/actions/runs/5500607432/jobs/10049469431?pr=32). Recently, [breaking changes](https://github.com/bigcommerce/api-specs/pull/1278) have been introduced to the [API Specs repo](https://github.com/bigcommerce/api-specs/tree/main) - this has caused the Node API client to break as Catalog has been converted from a file to a [directory](https://github.com/bigcommerce/api-specs/tree/main/reference/catalog) of files.

#### Tickets / Documentation
[APPEX-585](https://bigcommercecloud.atlassian.net/jira/software/c/projects/APPEX/boards/9?modal=detail&selectedIssue=APPEX-585)

#### Testing
Updated and added unit tests
Files are generated when running npm run generate

cc @bigcommerce/gta-dt


[APPEX-585]: https://bigcommercecloud.atlassian.net/browse/APPEX-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ