### PR TITLE
chore: APPEX-589 update version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigcommerce/api-nodejs",
-  "version": "0.1.1-alpha",
+  "version": "0.1.2-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/api-nodejs",
-      "version": "0.1.1-alpha",
+      "version": "0.1.2-alpha",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/api-nodejs",
-  "version": "0.1.1-alpha",
+  "version": "0.1.2-alpha",
   "author": "BigCommerce",
   "license": "MIT",
   "description": "A node module for authentication and communication with the BigCommerce API",


### PR DESCRIPTION
#### What?
Update @bigcommerce-api-node version to `0.1.2-alpha`

Note: Pending to create tag to manually add the release and publish via npm

#### Tickets / Documentation
https://bigcommercecloud.atlassian.net/browse/APPEX-589


cc @bigcommerce/gta-dt
