### PR TITLE
Add timeout parameter to prevent "hanging" requests

### DIFF
--- a/src/RestClient/RestClient.ts
+++ b/src/RestClient/RestClient.ts
@@ -24,6 +24,7 @@ class RestClient {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         'X-Auth-Token': config.accessToken,
       },
+      timeout: config.timeout,
     });
 
     this.rateLimitManager = new RateLimitManager(

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface RestClientConfig {
   accessToken: string;
   apiHost?: string;
   rateLimitConfig?: RateLimitConfig;
+  timeout?: number;
 }
 
 export interface RateLimitStatus {


### PR DESCRIPTION

#### What?

Since RestClient does not set the axios default timeout, requests may potentially "hang" indefinitely or until the backend terminates the connection.
Specifying the timeout parameter in RestClientConfig helps to control client behaviour and make it more predictable. 

For further justification see also https://geshan.com.np/blog/2022/11/axios-timeout/
